### PR TITLE
Add support for pathfinding around obstacles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9417,6 +9417,11 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1054,6 +1054,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/delaunator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/delaunator/-/delaunator-3.0.0.tgz",
+      "integrity": "sha512-x8XXE/QqXUPafkqFXeJCQCq/S81IW/t49Nnhgx3yKmGwL89qFRxnXn5qtcil9GO3gVkjGy4SwgacOjCN1B6b7w=="
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -2647,6 +2652,11 @@
           "dev": true
         }
       }
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
     },
     "delayed-stream": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7275,12 +7275,13 @@
       "dev": true
     },
     "nav2d": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nav2d/-/nav2d-1.1.0.tgz",
-      "integrity": "sha512-D4lfXFxwZByC5AZ73309HAEVNeWjI6pBw+rehWqPLMbO60dRNmtIejm3MTC5TDYVIQI7OS0fYmsk/t+dFOBreQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nav2d/-/nav2d-1.2.0.tgz",
+      "integrity": "sha512-MwtF13TBpmh7H/4jtM4gpw6/Q+LbBaCLFwUzeDE8k1rxV6UWNjT+uNBmviCM5tP3OLRPiLranjSuWCqwwhy6Vg==",
       "requires": {
         "earcut": "^2.2.2",
         "point-in-polygon": "^1.0.1",
+        "prettier": "^2.0.2",
         "simple-quadtree": "^0.1.3",
         "tinyqueue": "^2.0.3",
         "uuidv4": "^6.0.6"
@@ -8035,6 +8036,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "prettier": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw=="
     },
     "private": {
       "version": "0.1.8",
@@ -10200,17 +10206,23 @@
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "uuidv4": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.0.6.tgz",
-      "integrity": "sha512-10YcruyGJtsG5SJnPG+8atr8toJa7xAOrcO7B7plYYiwpH1mQ8UZHjNSa2MrwGi6KWuyVrXGHr+Rce22F9UAiw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.3.tgz",
+      "integrity": "sha512-4hxGisl76Y6A7nkadg5gMrPGVYVGLmJ3fZHVvmnXsy+8DMA7n7YV/4Y72Fw38CCwpZpyPgOaa/4YxhkCYwyNNQ==",
       "requires": {
-        "uuid": "7.0.2"
+        "@types/uuid": "8.3.0",
+        "uuid": "8.3.0"
       },
       "dependencies": {
+        "@types/uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
+        },
         "uuid": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
-          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2765,6 +2765,11 @@
         }
       }
     },
+    "earcut": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
+      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -7207,6 +7212,18 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "nav2d": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nav2d/-/nav2d-1.1.0.tgz",
+      "integrity": "sha512-D4lfXFxwZByC5AZ73309HAEVNeWjI6pBw+rehWqPLMbO60dRNmtIejm3MTC5TDYVIQI7OS0fYmsk/t+dFOBreQ==",
+      "requires": {
+        "earcut": "^2.2.2",
+        "point-in-polygon": "^1.0.1",
+        "simple-quadtree": "^0.1.3",
+        "tinyqueue": "^2.0.3",
+        "uuidv4": "^6.0.6"
+      }
+    },
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
@@ -7931,6 +7948,11 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
+    },
+    "point-in-polygon": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
+      "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -8683,6 +8705,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-quadtree": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/simple-quadtree/-/simple-quadtree-0.1.3.tgz",
+      "integrity": "sha1-kRWQeNOmCByInbBaM11Mm1peOIg="
     },
     "sisteransi": {
       "version": "1.0.3",
@@ -10015,6 +10042,21 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    },
+    "uuidv4": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.0.6.tgz",
+      "integrity": "sha512-10YcruyGJtsG5SJnPG+8atr8toJa7xAOrcO7B7plYYiwpH1mQ8UZHjNSa2MrwGi6KWuyVrXGHr+Rce22F9UAiw==",
+      "requires": {
+        "uuid": "7.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+        }
+      }
     },
     "v8-compile-cache": {
       "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1834,6 +1834,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big-rat": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
+      "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "bn.js": "^4.11.6",
+        "double-bits": "^1.1.1"
+      }
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1846,6 +1856,16 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "binary-search-bounds": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
+      "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
+    },
+    "bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
+    },
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
@@ -1855,8 +1875,16 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "dev": true
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "box-intersect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.2.tgz",
+      "integrity": "sha512-yJeMwlmFPG1gIa7Rs/cGXeI6iOj6Qz5MG5PE61xLKpElUGzmJ4abm+qsLpzxKJFpsSDq742BQEocr8dI2t8Nxw==",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
+      }
     },
     "boxen": {
       "version": "1.3.0",
@@ -2162,6 +2190,16 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "cdt2d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
+      "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
+      "requires": {
+        "binary-search-bounds": "^2.0.3",
+        "robust-in-sphere": "^1.1.3",
+        "robust-orientation": "^1.1.3"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2273,6 +2311,20 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "clean-pslg": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
+      "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
+      "requires": {
+        "big-rat": "^1.0.3",
+        "box-intersect": "^1.0.1",
+        "nextafter": "^1.0.0",
+        "rat-vec": "^1.1.1",
+        "robust-segment-intersect": "^1.0.1",
+        "union-find": "^1.0.2",
+        "uniq": "^1.0.1"
       }
     },
     "cli-boxes": {
@@ -2720,6 +2772,16 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
+    },
+    "double-bits": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/double-bits/-/double-bits-1.1.1.tgz",
+      "integrity": "sha1-WKu6RUlNpND6Nrc60RoobJGEscY="
+    },
+    "dup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
+      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -7230,6 +7292,14 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
+    "nextafter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
+      "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
+      "requires": {
+        "double-bits": "^1.1.0"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -8119,6 +8189,14 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "rat-vec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
+      "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
+      "requires": {
+        "big-rat": "^1.0.3"
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -8464,6 +8542,55 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "robust-in-sphere": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.1.3.tgz",
+      "integrity": "sha1-HFiD0WpOkjkpR27zSBmFe/Kpz3U=",
+      "requires": {
+        "robust-scale": "^1.0.0",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
+      }
+    },
+    "robust-orientation": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
+      "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "requires": {
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
+      }
+    },
+    "robust-scale": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "requires": {
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
+      }
+    },
+    "robust-segment-intersect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
+      "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
+      "requires": {
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "robust-subtract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+    },
+    "robust-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
     },
     "rsvp": {
       "version": "4.8.5",
@@ -9778,6 +9905,16 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "two-product": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+    },
+    "two-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -9792,6 +9929,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedarray-pool": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
+      "requires": {
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
     },
     "typescript": {
       "version": "3.7.4",
@@ -9843,6 +9989,11 @@
         }
       }
     },
+    "union-find": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
+      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg="
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -9854,6 +10005,11 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "delaunator": "^4.0.1",
     "moment": "^2.24.0",
     "nanoid": "^2.1.8",
-    "nav2d": "^1.1.0",
+    "nav2d": "^1.2.0",
     "pino": "^5.16.0",
     "source-map-support": "^0.5.16",
     "three": "0.112.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "@types/delaunator": "^3.0.0",
     "camera-controls": "1.18.2",
     "lodash": "^4.17.19",
+    "cdt2d": "^1.0.0",
+    "clean-pslg": "^1.1.2",
     "delaunator": "^4.0.1",
     "moment": "^2.24.0",
     "nanoid": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,10 @@
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
+    "@types/delaunator": "^3.0.0",
     "camera-controls": "1.18.2",
     "lodash": "^4.17.19",
+    "delaunator": "^4.0.1",
     "moment": "^2.24.0",
     "nanoid": "^2.1.8",
     "pino": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "delaunator": "^4.0.1",
     "moment": "^2.24.0",
     "nanoid": "^2.1.8",
+    "nav2d": "^1.1.0",
     "pino": "^5.16.0",
     "source-map-support": "^0.5.16",
     "three": "0.112.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "source-map-support": "^0.5.16",
     "three": "0.112.1",
     "three.meshline": "v1.2.0",
+    "tinyqueue": "^2.0.3",
     "tslib": "^1.10.0",
     "uuid": "^3.3.3"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,7 +98,7 @@ function main() {
   renderer.animate(true);
   window.renderer = renderer;
 
-  let triangulatedMap = rtt_engine.triangulate(map.worldSize, map.obstructions);
+  let triangulatedMap = rtt_engine.triangulate(map.worldSize, map.obstructions, 5);
   let triangulatedMapPresenter = new rtt_threejs_renderer.TriangulatedMapPresenter(triangulatedMap, renderer.gameCoordsGroup);
   //triangulatedMapPresenter.predraw();
   let navmesh = rtt_engine.triangulatedMapToNavMesh(triangulatedMap);

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,25 +83,23 @@ function main() {
     }]
   };
 
-  let renderer = new rtt_threejs_renderer.Renderer(map.worldSize, window, document);
-  renderer.animate(true);
-
-  let mapPresenter = new rtt_threejs_renderer.MapPresenter(map, renderer.gameCoordsGroup);
-  mapPresenter.predraw();
   const bounds = new rtt_engine.Bounds(0, map.worldSize, 0, map.worldSize);
-
-  // const grid = new THREE.GridHelper(map.worldSize, map.worldSize / 25);
-  // grid.position.z = -0.1;
-  // grid.rotation.x = Math.PI / 2;
-  // renderer.scene.add(grid);
 
   let game = rtt_engine.gameFromConfig(config);
   const obstructionQuadtree = rtt_engine.IQuadrant.fromEntityCollisions(bounds, game.obstructions);
   window.game = game;
-  window.renderer = renderer;
   window.rtt_engine = rtt_engine;
   window.rtt_threejs_renderer = rtt_threejs_renderer;
 
+  // FIXME: Remove after debugging
+  //return;
+
+  let renderer = new rtt_threejs_renderer.Renderer(map.worldSize, window, document);
+  renderer.animate(true);
+  window.renderer = renderer;
+
+  let mapPresenter = new rtt_threejs_renderer.MapPresenter(map, renderer.gameCoordsGroup);
+  mapPresenter.predraw();
   let powerSourcePresenter = new rtt_threejs_renderer.PowerSourcePresenter(game, renderer.gameCoordsGroup);
   powerSourcePresenter.predraw();
   let obstructionPresenter = new rtt_threejs_renderer.ObstructionPresenter(game, renderer.gameCoordsGroup);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,15 +21,18 @@ function main() {
       new rtt_engine.Vector(edge, edge),
       new rtt_engine.Vector(edge + spacing, edge),
       new rtt_engine.Vector(edge + spacing, edge + spacing),
+      new rtt_engine.Vector(edge + spacing * 1.5, edge + spacing * 1.5),
       new rtt_engine.Vector(edge, edge + spacing),
 
       new rtt_engine.Vector(size - edge, edge),
       new rtt_engine.Vector(size - edge - spacing, edge),
       new rtt_engine.Vector(size - edge - spacing, edge + spacing),
+      new rtt_engine.Vector(size - edge - spacing * 1.5, edge + spacing * 1.5),
       new rtt_engine.Vector(size - edge, edge + spacing),
 
       new rtt_engine.Vector(size - edge, size - edge - spacing),
       new rtt_engine.Vector(size - edge - spacing, size - edge - spacing),
+      new rtt_engine.Vector(size - edge - spacing * 1.5, size - edge - spacing * 1.5),
       new rtt_engine.Vector(size - edge - spacing, size - edge),
       new rtt_engine.Vector(size - edge, size - edge),
 
@@ -37,6 +40,7 @@ function main() {
       new rtt_engine.Vector(edge, size - edge),
       new rtt_engine.Vector(edge, size - edge - spacing),
       new rtt_engine.Vector(edge + spacing, size - edge - spacing),
+      new rtt_engine.Vector(edge + spacing * 1.5, size - edge - spacing * 1.5),
     ],
   };
   const config = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,7 +100,16 @@ function main() {
 
   let triangulatedMap = rtt_engine.triangulate(map.worldSize, map.obstructions);
   let triangulatedMapPresenter = new rtt_threejs_renderer.TriangulatedMapPresenter(triangulatedMap, renderer.gameCoordsGroup);
-  triangulatedMapPresenter.predraw();
+  //triangulatedMapPresenter.predraw();
+  let navmesh = rtt_engine.triangulatedMapToNavMesh(triangulatedMap);
+  window.navmesh = navmesh;
+  window.routeBetween = function(from, to) {
+    let navmeshRoute = navmesh.findPath([from.x, from.y], [to.x, to.y]);
+    if (!navmeshRoute || navmeshRoute.length == 0) {
+      return null;
+    }
+    return navmeshRoute.map((p) => new rtt_engine.Vector(p.x, p.y));
+  };
 
   let mapPresenter = new rtt_threejs_renderer.MapPresenter(map, renderer.gameCoordsGroup);
   mapPresenter.predraw();
@@ -272,6 +281,8 @@ function main() {
   });
 
   let path: any;
+  let pathStart: any;
+  let pathEnd: any;
   setInterval(() => {
     rtt_threejs_renderer.time("update", () => {
       for (let ai of ais) {
@@ -334,36 +345,69 @@ function main() {
         }
       }
 
-      if (game.updateCounter % 100 == 0) {
-        if (path != undefined) {
-          renderer.gameCoordsGroup.remove(path);
-          path.material.dispose();
-          path.geometry.dispose();
-          path = undefined;
-        }
-        let material = new THREE.LineBasicMaterial({ color: 0xffffff });
-        let from = new rtt_engine.Vector(
-          Math.random() * map.worldSize,
-          Math.random() * map.worldSize
-        );
-        let to = new rtt_engine.Vector(
-          Math.random() * map.worldSize,
-          Math.random() * map.worldSize
-        );
-        let route = rtt_engine.findPathWithAStar({
-          collisionRadius: 10,
-          position: from,
-        }, to, triangulatedMap);
-        if (route == undefined) {
-          console.log(`route not found from ${from.stringify()} to ${to.stringify()}`);
-        } else {
-          console.log(`route found from ${from.stringify()} to ${to.stringify()}: ${route.map((p) => p.stringify())}`);
-          let points = route.map((p) => new THREE.Vector3(p.x, p.y, 6));
-          let geometry = new THREE.BufferGeometry().setFromPoints(points);
-          path = new THREE.LineSegments(geometry, material);
-          renderer.gameCoordsGroup.add(path);
-        }
-      }
+      // if (game.updateCounter % 100 == 0) {
+      //   if (path != undefined) {
+      //     renderer.gameCoordsGroup.remove(path);
+      //     path.material.dispose();
+      //     path.geometry.dispose();
+      //     path = undefined;
+      //   }
+      //   if (pathStart != undefined) {
+      //     renderer.gameCoordsGroup.remove(pathStart);
+      //     pathStart.material.dispose();
+      //     pathStart.geometry.dispose();
+      //     pathStart = undefined;
+      //   }
+      //   if (pathEnd != undefined) {
+      //     renderer.gameCoordsGroup.remove(pathEnd);
+      //     pathEnd.material.dispose();
+      //     pathEnd.geometry.dispose();
+      //     pathEnd = undefined;
+      //   }
+      //   let material = new THREE.LineBasicMaterial({ color: 0xffffff });
+      //   let from = new rtt_engine.Vector(
+      //     Math.random() * map.worldSize,
+      //     Math.random() * map.worldSize
+      //   );
+      //   let to = new rtt_engine.Vector(
+      //     Math.random() * map.worldSize,
+      //     Math.random() * map.worldSize
+      //   );
+
+      //   // from.x = 321.94381764911583;
+      //   // from.y = 311.00705914346884;
+      //   // to.x = 145.50164006384801;
+      //   // to.y = 335.0348767805669;
+      //   if (to.y < from.y || to.x < from.x) {
+      //     const temp = to;
+      //     to = from;
+      //     from = temp;
+      //   }
+
+      //   pathStart = new THREE.Mesh(new THREE.CircleBufferGeometry(5), new THREE.MeshBasicMaterial({color: 0x00ff00}));
+      //   pathStart.position.x = from.x;
+      //   pathStart.position.y = from.y;
+      //   //renderer.gameCoordsGroup.add(pathStart);
+      //   pathEnd = new THREE.Mesh(new THREE.CircleBufferGeometry(5), new THREE.MeshBasicMaterial({color: 0xff0000}));
+      //   pathEnd.position.x = to.x;
+      //   pathEnd.position.y = to.y;
+      //   //renderer.gameCoordsGroup.add(pathEnd);
+
+      //   let route = navmesh.findPath([from.x, from.y], [to.x, to.y]);
+      //   // let route = rtt_engine.findPathWithAStar({
+      //   //   collisionRadius: 10,
+      //   //   position: from,
+      //   // }, to, triangulatedMap);
+      //   if (route == undefined) {
+      //     console.log(`route not found from ${from.stringify()} to ${to.stringify()}`);
+      //   } else {
+      //     console.log(`route found from ${from.stringify()} to ${to.stringify()}: ${route.map((p) => [p.x, p.y])}`);
+      //     let points = route.map((p) => new THREE.Vector3(p.x, p.y, 0));
+      //     let geometry = new THREE.BufferGeometry().setFromPoints(points);
+      //     path = new THREE.LineSegments(geometry, material);
+      //     //renderer.gameCoordsGroup.add(path);
+      //   }
+      // }
     });
 
     rtt_threejs_renderer.time("update rendering", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,19 @@ function main() {
   const map = {
     name: 'double-cross',
     worldSize: size,
-    obstructions: [],
+    obstructions: [
+      new rtt_engine.Obstruction(0, edge + spacing * 0.5, edge + spacing * 2, edge + spacing * 2.5),
+      new rtt_engine.Obstruction(edge + spacing * 2, edge + spacing * 2.5, 0, edge + spacing * 0.5),
+
+      new rtt_engine.Obstruction(size - edge - spacing * 0.5, size, edge + spacing * 2, edge + spacing * 2.5),
+      new rtt_engine.Obstruction(size - edge - spacing * 2.5, size - edge - spacing * 2, 0, edge + spacing * 0.5),
+
+      new rtt_engine.Obstruction(size - edge - spacing * 0.5, size, size - edge - spacing * 2.5, size - edge - spacing * 2),
+      new rtt_engine.Obstruction(size - edge - spacing * 2.5, size - edge - spacing * 2, size - edge - spacing * 0.5, size),
+
+      new rtt_engine.Obstruction(0, edge + spacing * 0.5, size - edge - spacing * 2.5, size - edge - spacing * 2),
+      new rtt_engine.Obstruction(edge + spacing * 2, edge + spacing * 2.5, size - edge - spacing * 0.5, size),
+    ],
     powerSources: [
       new rtt_engine.Vector(edge, edge),
       new rtt_engine.Vector(edge + spacing, edge),

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,17 +14,8 @@ function main() {
     name: 'double-cross',
     worldSize: size,
     obstructions: [
-      new rtt_engine.Obstruction(0, edge + spacing * 0.5, edge + spacing * 2, edge + spacing * 2.5),
-      new rtt_engine.Obstruction(edge + spacing * 2, edge + spacing * 2.5, 0, edge + spacing * 0.5),
-
-      new rtt_engine.Obstruction(size - edge - spacing * 0.5, size, edge + spacing * 2, edge + spacing * 2.5),
-      new rtt_engine.Obstruction(size - edge - spacing * 2.5, size - edge - spacing * 2, 0, edge + spacing * 0.5),
-
-      new rtt_engine.Obstruction(size - edge - spacing * 0.5, size, size - edge - spacing * 2.5, size - edge - spacing * 2),
-      new rtt_engine.Obstruction(size - edge - spacing * 2.5, size - edge - spacing * 2, size - edge - spacing * 0.5, size),
-
-      new rtt_engine.Obstruction(0, edge + spacing * 0.5, size - edge - spacing * 2.5, size - edge - spacing * 2),
-      new rtt_engine.Obstruction(edge + spacing * 2, edge + spacing * 2.5, size - edge - spacing * 0.5, size),
+      new rtt_engine.Obstruction(edge + spacing * 2, size - edge - spacing * 2, size / 2 - spacing, size / 2 + spacing),
+      new rtt_engine.Obstruction(size / 2 - spacing, size / 2 + spacing, edge + spacing * 2, size - edge - spacing * 2),
     ],
     powerSources: [
       new rtt_engine.Vector(edge, edge),
@@ -46,19 +37,6 @@ function main() {
       new rtt_engine.Vector(edge, size - edge),
       new rtt_engine.Vector(edge, size - edge - spacing),
       new rtt_engine.Vector(edge + spacing, size - edge - spacing),
-
-      new rtt_engine.Vector(crossSpacing, size / 2),
-      new rtt_engine.Vector(crossSpacing * 2, size / 2),
-      new rtt_engine.Vector(crossSpacing * 3, size / 2),
-      new rtt_engine.Vector(crossSpacing * 4, size / 2),
-      new rtt_engine.Vector(crossSpacing * 5, size / 2),
-      new rtt_engine.Vector(crossSpacing * 6, size / 2),
-      new rtt_engine.Vector(size / 2, crossSpacing),
-      new rtt_engine.Vector(size / 2, crossSpacing * 2),
-      new rtt_engine.Vector(size / 2, crossSpacing * 3),
-      new rtt_engine.Vector(size / 2, crossSpacing * 4),
-      new rtt_engine.Vector(size / 2, crossSpacing * 5),
-      new rtt_engine.Vector(size / 2, crossSpacing * 6),
     ],
   };
   const config = {

--- a/src/rtt_engine/config.ts
+++ b/src/rtt_engine/config.ts
@@ -2,7 +2,7 @@ import { Vector } from './vector';
 import { Game } from './game';
 import { Player, IColor } from './player';
 import { PlayerUnits } from './player_units';
-import { PowerSource } from './entities/power_source';
+import { PowerSource, Obstruction } from './entities';
 import { Commander } from './entities/commander';
 
 export interface IGameConfig {
@@ -21,14 +21,15 @@ export interface IMap {
   name: string;
   worldSize: number;
   powerSources: Vector[];
+  obstructions: Obstruction[];
 }
 
-export function gameFromConfig(gameConfig: IGameConfig): Game {
+export function gameFromConfig(gameConfig: IGameConfig, sandbox = false): Game {
   let powerSources = gameConfig.map.powerSources.map((v) => new PowerSource(v));
   let players = gameConfig.players.map((p) => {
     const player = new Player(p.name, p.color, new PlayerUnits(gameConfig.unitCap));
     player.units.commander = new Commander(p.commanderPosition, Math.random() * 2 * Math.PI, player);
     return player;
   });
-  return new Game(powerSources, players);
+  return new Game(powerSources, players, gameConfig.map.obstructions, sandbox);
 }

--- a/src/rtt_engine/entities/index.ts
+++ b/src/rtt_engine/entities/index.ts
@@ -9,3 +9,4 @@ export * from './factory';
 export * from './power_generator';
 export * from './power_source';
 export * from './turret';
+export * from './obstruction';

--- a/src/rtt_engine/entities/lib/vehicle.ts
+++ b/src/rtt_engine/entities/lib/vehicle.ts
@@ -66,7 +66,7 @@ export class Vehicle extends Manoeuvrable(Unit) {
       return false;
     }
 
-    if (!this.routeTo || !this.route || this.route.length == 0 || !this.routeTo.equals(manoeuvreOrder.destination)) {
+    if (!this.routeTo || !this.route || this.route.length == 0 || !this.routeTo.equals(manoeuvreOrder.destination) || Math.random() < 0.1) {
       // Find route
       this.routeTo = manoeuvreOrder.destination;
       this.route = window.routeBetween(this.position, this.routeTo);

--- a/src/rtt_engine/entities/lib/vehicle.ts
+++ b/src/rtt_engine/entities/lib/vehicle.ts
@@ -22,6 +22,8 @@ export interface IVehicleConfig extends IUnitConfig, IManoeuverableConfig {
 export class Vehicle extends Manoeuvrable(Unit) {
   public movementRate: number;
   public turnRate: number;
+  public route: Vector[] | null;
+  public routeTo: Vector | null;
 
   constructor(cfg: IVehicleConfig) {
     cfg.constructableByMobileUnits = false;
@@ -42,6 +44,8 @@ export class Vehicle extends Manoeuvrable(Unit) {
     super(cfg);
     this.movementRate = cfg.movementRate;
     this.turnRate = cfg.turnRate;
+    this.route = null;
+    this.routeTo = null;
   }
 
   public update() {
@@ -58,10 +62,38 @@ export class Vehicle extends Manoeuvrable(Unit) {
   protected manoeuvre(manoeuvreOrder: { destination: Vector }): boolean {
     const distanceToDestination = Vector.subtract(this.position, manoeuvreOrder.destination).magnitude();
     if (distanceToDestination < 10) {
+      this.routeTo = null;
       return false;
-    } else if (this.shouldTurnLeftToReach(manoeuvreOrder.destination) && Math.random() > 0.2) {
+    }
+
+    if (!this.routeTo || !this.route || this.route.length == 0 || !this.routeTo.equals(manoeuvreOrder.destination)) {
+      // Find route
+      this.routeTo = manoeuvreOrder.destination;
+      this.route = window.routeBetween(this.position, this.routeTo);
+      console.log(this.route);
+      //this.route?.shift();
+    }
+
+    if (!this.route || this.route.length == 0) {
+      this.routeTo = null;
+      return false;
+    }
+
+    let nextRouteDestination = this.route[0];
+    let distanceToNextRouteDestination = Vector.subtract(this.position, nextRouteDestination).magnitude();
+    while (distanceToNextRouteDestination < 5) {
+      this.route.shift();
+      if (this.route.length == 0) {
+        this.routeTo = null;
+        return false;
+      }
+      nextRouteDestination = this.route[0];
+      distanceToNextRouteDestination = Vector.subtract(this.position, nextRouteDestination).magnitude();
+    }
+
+    if (this.shouldTurnLeftToReach(nextRouteDestination) && Math.random() > 0.2) {
       this.updateVelocity(-this.physics.turningAngle());
-    } else if (this.shouldTurnRightToReach(manoeuvreOrder.destination) && Math.random() > 0.2) {
+    } else if (this.shouldTurnRightToReach(nextRouteDestination) && Math.random() > 0.2) {
       this.updateVelocity(this.physics.turningAngle());
     } else {
       this.updateVelocity(0);

--- a/src/rtt_engine/entities/obstruction.ts
+++ b/src/rtt_engine/entities/obstruction.ts
@@ -22,7 +22,7 @@ export class Obstruction extends Collidable(Entity) {
     this.bottom = bottom;
   }
 
-  contains(unit: ICollidable): boolean {
+  contains(unit: { position: Vector, collisionRadius: number }): boolean {
     // FIXME: One X and Y edge has to be made inclusive, or it's possible for a unit
     // to slide between two touching obstructions.
     const contained = (
@@ -37,7 +37,7 @@ export class Obstruction extends Collidable(Entity) {
     return contained;
   }
 
-  collide(unit: ICollidable): void {
+  collide(unit: { position: Vector, collisionRadius: number }): void {
     if (!this.contains(unit)) {
       return;
     }

--- a/src/rtt_engine/entities/obstruction.ts
+++ b/src/rtt_engine/entities/obstruction.ts
@@ -44,33 +44,32 @@ export class Obstruction extends Collidable(Entity) {
   }
 
   collide(unit: { position: Vector, collisionRadius: number }): void {
-    if (!this.contains(unit)) {
-      return;
-    }
+    console.log("collided", unit);
+    while (this.contains(unit)) {
+      const aboveY = this.top - unit.collisionRadius;
+      const belowY = this.bottom + unit.collisionRadius;
+      const leftX = this.left - unit.collisionRadius;
+      const rightX = this.right + unit.collisionRadius;
 
-    const aboveY = this.top - unit.collisionRadius;
-    const belowY = this.bottom + unit.collisionRadius;
-    const leftX = this.left - unit.collisionRadius;
-    const rightX = this.right + unit.collisionRadius;
+      const distanceToBeAbove = Math.abs(unit.position.y - aboveY);
+      const distanceToBeBelow = Math.abs(unit.position.y - belowY);
+      const distanceToBeLeft = Math.abs(unit.position.x - leftX);
+      const distanceToBeRight = Math.abs(unit.position.x - rightX);
 
-    const distanceToBeAbove = Math.abs(unit.position.y - aboveY);
-    const distanceToBeBelow = Math.abs(unit.position.y - belowY);
-    const distanceToBeLeft = Math.abs(unit.position.x - leftX);
-    const distanceToBeRight = Math.abs(unit.position.x - rightX);
-
-    const minY = Math.min(distanceToBeAbove, distanceToBeBelow);
-    const minX = Math.min(distanceToBeLeft, distanceToBeRight);
-    if (minY < minX) {
-      if (distanceToBeAbove < distanceToBeBelow) {
-        unit.position.y = aboveY;
+      const minY = Math.min(distanceToBeAbove, distanceToBeBelow);
+      const minX = Math.min(distanceToBeLeft, distanceToBeRight);
+      if (minY < minX) {
+        if (distanceToBeAbove < distanceToBeBelow) {
+          unit.position.y = aboveY - 1;
+        } else {
+          unit.position.y = belowY + 1;
+        }
       } else {
-        unit.position.y = belowY;
-      }
-    } else {
-      if (distanceToBeLeft < distanceToBeRight) {
-        unit.position.x = leftX;
-      } else {
-        unit.position.x = rightX;
+        if (distanceToBeLeft < distanceToBeRight) {
+          unit.position.x = leftX - 1;
+        } else {
+          unit.position.x = rightX + 1;
+        }
       }
     }
 

--- a/src/rtt_engine/entities/obstruction.ts
+++ b/src/rtt_engine/entities/obstruction.ts
@@ -1,0 +1,116 @@
+import { Vector } from '../vector';
+import { Entity } from './lib';
+import { Collidable, ICollidableConfig, ICollidable } from './abilities';
+
+export class Obstruction extends Collidable(Entity) {
+  player: null;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+
+  constructor(left: number, right: number, top: number, bottom: number) {
+    const position = new Vector(
+      (left + right) / 2,
+      (top + bottom) / 2,
+    );
+    const collisionRadius = Math.max(right - left, bottom - top) / 2 + 0.1;
+    super({ position, collisionRadius });
+    this.left = left;
+    this.right = right;
+    this.top = top;
+    this.bottom = bottom;
+  }
+
+  contains(unit: ICollidable): boolean {
+    // FIXME: One X and Y edge has to be made inclusive, or it's possible for a unit
+    // to slide between two touching obstructions.
+    const contained = (
+      unit.position.x + unit.collisionRadius > this.left
+      && unit.position.x - unit.collisionRadius <= this.right
+      && unit.position.y + unit.collisionRadius > this.top
+      && unit.position.y - unit.collisionRadius <= this.bottom
+    );
+    // if (contained) {
+    //   console.log("obstruction at [" + JSON.stringify([this.left, this.right, this.top, this.bottom]) + "] contained unit at [" + JSON.stringify(unit.position) + "]")
+    // }
+    return contained;
+  }
+
+  collide(unit: ICollidable): void {
+    if (!this.contains(unit)) {
+      return;
+    }
+
+    const aboveY = this.top - unit.collisionRadius;
+    const belowY = this.bottom + unit.collisionRadius;
+    const leftX = this.left - unit.collisionRadius;
+    const rightX = this.right + unit.collisionRadius;
+
+    const distanceToBeAbove = Math.abs(unit.position.y - aboveY);
+    const distanceToBeBelow = Math.abs(unit.position.y - belowY);
+    const distanceToBeLeft = Math.abs(unit.position.x - leftX);
+    const distanceToBeRight = Math.abs(unit.position.x - rightX);
+
+    const minY = Math.min(distanceToBeAbove, distanceToBeBelow);
+    const minX = Math.min(distanceToBeLeft, distanceToBeRight);
+    if (minY < minX) {
+      if (distanceToBeAbove < distanceToBeBelow) {
+        unit.position.y = aboveY;
+      } else {
+        unit.position.y = belowY;
+      }
+    } else {
+      if (distanceToBeLeft < distanceToBeRight) {
+        unit.position.x = leftX;
+      } else {
+        unit.position.x = rightX;
+      }
+    }
+
+    // let dx = Infinity;
+    // const leftX = this.left - (unit.position.x + unit.collisionRadius);
+    // if (leftX < 0) {
+    //   // unit.position.x += leftX;
+    //   dx = leftX;
+    // } else {
+    //   const rightX = this.right - (unit.position.x - unit.collisionRadius);
+    //   if (rightX > 0) {
+    //     dx = rightX;
+    //     // unit.position.x += rightX;
+    //   } else {
+    //     // ???
+    //   }
+    // }
+
+    // let dy = Infinity;
+    // const topX = this.top - (unit.position.y + unit.collisionRadius);
+    // if (topX < 0) {
+    //   // unit.position.y += topX;
+    //   dy = topX;
+    // } else {
+    //   const bottomY = this.bottom - (unit.position.y - unit.collisionRadius);
+    //   if (bottomY > 0) {
+    //     // unit.position.y += bottomY;
+    //     dy = bottomY;
+    //   } else {
+    //     // ???
+    //   }
+    // }
+
+    // dx = Math.min(
+    //   this.left - (unit.position.x + unit.collisionRadius),
+    //   this.right - (unit.position.x - unit.collisionRadius)
+    // );
+    // dy = Math.min(
+    //   this.top - (unit.position.y + unit.collisionRadius),
+    //   this.bottom - (unit.position.y - unit.collisionRadius)
+    // );
+    // // Move to the closest edge, but only in x OR y. Not ideal at all.
+    // if (Math.abs(dx) < Math.abs(dy)) {
+    //   unit.position.x += dx;
+    // } else {
+    //   unit.position.y += dy;
+    // }
+  }
+}

--- a/src/rtt_engine/entities/obstruction.ts
+++ b/src/rtt_engine/entities/obstruction.ts
@@ -10,6 +10,12 @@ export class Obstruction extends Collidable(Entity) {
   bottom: number;
 
   constructor(left: number, right: number, top: number, bottom: number) {
+    if (left >= right) {
+      throw "left bigger than right;"
+    }
+    if (top >= bottom) {
+      throw "top bigger than bottom;"
+    }
     const position = new Vector(
       (left + right) / 2,
       (top + bottom) / 2,

--- a/src/rtt_engine/game.ts
+++ b/src/rtt_engine/game.ts
@@ -1,4 +1,4 @@
-import { PowerSource } from './entities';
+import { PowerSource, Obstruction } from './entities';
 import { Player } from './player';
 
 export class Game {
@@ -8,14 +8,16 @@ export class Game {
   public updateCounter: number;
   public winner: string | null;
   public winTime: Date | null;
+  public obstructions: Obstruction[];
 
-  constructor(powerSources: readonly PowerSource[], players: readonly Player[], sandbox = false) {
+  constructor(powerSources: readonly PowerSource[], players: readonly Player[], obstructions: Obstruction[], sandbox = false) {
     this.powerSources = powerSources;
     this.players = players;
     this.sandbox = sandbox;
     this.updateCounter = 0;
     this.winner = null;
     this.winTime = null;
+    this.obstructions = obstructions;
   }
 
   public update() {

--- a/src/rtt_engine/index.ts
+++ b/src/rtt_engine/index.ts
@@ -5,3 +5,4 @@ export * from './player_units';
 export * from './vector';
 export * from './config';
 export * from './quadtree';
+export * from './pathfinding';

--- a/src/rtt_engine/pathfinding.ts
+++ b/src/rtt_engine/pathfinding.ts
@@ -12,15 +12,15 @@ export interface ITriangulatedMap {
   passableTriangles: [number, number, number][];
 }
 
-export function triangulate(worldSize: number, obstructions: Obstruction[]): ITriangulatedMap {
+export function triangulate(worldSize: number, obstructions: Obstruction[], clearance: number): ITriangulatedMap {
   const points: [number, number][] = [];
   const boundaryEdges: [number, number][] = [];
 
   // Add the world boundaries
-  points.push([0, 0]);
-  points.push([0, worldSize]);
-  points.push([worldSize, worldSize]);
-  points.push([worldSize, 0]);
+  points.push([clearance, clearance]);
+  points.push([clearance, worldSize - clearance]);
+  points.push([worldSize - clearance, worldSize - clearance]);
+  points.push([worldSize - clearance, clearance]);
   boundaryEdges.push([0, 1]);
   boundaryEdges.push([1, 2]);
   boundaryEdges.push([2, 3]);
@@ -29,10 +29,10 @@ export function triangulate(worldSize: number, obstructions: Obstruction[]): ITr
   // Add the obstructions
   for (let obstruction of obstructions) {
     const startIndex = points.length;
-    points.push([obstruction.left, obstruction.top]);
-    points.push([obstruction.right, obstruction.top]);
-    points.push([obstruction.right, obstruction.bottom]);
-    points.push([obstruction.left, obstruction.bottom]);
+    points.push([obstruction.left - clearance, obstruction.top - clearance]);
+    points.push([obstruction.right + clearance, obstruction.top - clearance]);
+    points.push([obstruction.right + clearance, obstruction.bottom + clearance]);
+    points.push([obstruction.left - clearance, obstruction.bottom + clearance]);
     boundaryEdges.push([startIndex, startIndex+1]);
     boundaryEdges.push([startIndex+1, startIndex+2]);
     boundaryEdges.push([startIndex+2, startIndex+3]);
@@ -45,6 +45,12 @@ export function triangulate(worldSize: number, obstructions: Obstruction[]): ITr
 
   const triangles = cdt2d(points, boundaryEdges);
 
+  // A triangle is impassable if:
+  // 1. Any of its points are outside the bounds of the world
+  //    This should be self-evident
+  // 2. The centre of the circle is inside an obstruction
+  //    This is true because we constrain the triangulation so that there
+  //    will be triangles aligned to the obstructions
   const passableTriangles: [number, number, number][] = [];
   for (let triangle of triangles) {
     let trianglePoints = triangle.map((i) => points[i]);
@@ -52,14 +58,18 @@ export function triangulate(worldSize: number, obstructions: Obstruction[]): ITr
       _.sum(trianglePoints.map((p) => p[0])) / 3,
       _.sum(trianglePoints.map((p) => p[1])) / 3,
     ];
-    let obstructed = false;
-    for (let obstruction of obstructions) {
-      if (obstruction.left < centreOfTriangle[0]
-        && obstruction.right > centreOfTriangle[0]
-        && obstruction.top < centreOfTriangle[1]
-        && obstruction.bottom > centreOfTriangle[1]) {
-        obstructed = true;
-        break;
+    let obstructed = trianglePoints.filter((p) => {
+      return (p[0] < 0 || p[1] < 0 || p[0] > worldSize || p[1] > worldSize);
+    }).length > 0;
+    if (!obstructed) {
+      for (let obstruction of obstructions) {
+        if (obstruction.left < centreOfTriangle[0]
+          && obstruction.right > centreOfTriangle[0]
+          && obstruction.top < centreOfTriangle[1]
+          && obstruction.bottom > centreOfTriangle[1]) {
+          obstructed = true;
+          break;
+        }
       }
     }
     if (!obstructed) {

--- a/src/rtt_engine/pathfinding.ts
+++ b/src/rtt_engine/pathfinding.ts
@@ -2,6 +2,7 @@ import { Vector } from './vector';
 import { Obstruction } from './entities';
 import TinyQueue from 'tinyqueue';
 import Delaunator from 'delaunator';
+import { NavMesh } from "nav2d";
 
 export interface IClearance {
   worldSize: number;
@@ -100,6 +101,7 @@ export interface ITriangulatedMap {
   pointObstruction: (number | undefined)[];
   triangles: Uint32Array;
   neighboursWithCost: [number, number][][];
+  badPoints: [number, number][];
 }
 
 export function triangulate(worldSize: number, obstructions: Obstruction[]): ITriangulatedMap {
@@ -110,11 +112,16 @@ export function triangulate(worldSize: number, obstructions: Obstruction[]): ITr
   points.push([worldSize, 0]);
   const pointObstruction = [undefined, undefined, undefined, undefined];
   let i = 0;
+  let badPoints: [number, number][] = [];
   for (let obstruction of obstructions) {
     points.push([obstruction.left, obstruction.top]);
     points.push([obstruction.right, obstruction.top]);
     points.push([obstruction.right, obstruction.bottom]);
     points.push([obstruction.left, obstruction.bottom]);
+    badPoints.push([obstruction.left, obstruction.top]);
+    badPoints.push([obstruction.right, obstruction.top]);
+    badPoints.push([obstruction.right, obstruction.bottom]);
+    badPoints.push([obstruction.left, obstruction.bottom]);
     pointObstruction.push(i, i, i, i);
     i++;
   }
@@ -143,7 +150,27 @@ export function triangulate(worldSize: number, obstructions: Obstruction[]): ITr
     pointObstruction,
     triangles: delauneyed.triangles,
     neighboursWithCost,
+    badPoints,
   };
+}
+
+export function triangulatedMapToNavMesh(triangulatedMap: ITriangulatedMap): NavMesh {
+  const trianglesAsArraysOfPoints: [number, number][][] = [];
+  for (let i = 0; i < triangulatedMap.triangles.length; i += 3) {
+    const p1N = triangulatedMap.triangles[i];
+    const p2N = triangulatedMap.triangles[i + 1];
+    const p3N = triangulatedMap.triangles[i + 2];
+    const p1 = triangulatedMap.points[p1N];
+    const p2 = triangulatedMap.points[p2N];
+    const p3 = triangulatedMap.points[p3N];
+    let pointObstructions = _.uniq([p1N, p2N, p3N].map((n) => triangulatedMap.pointObstruction[n]));
+    let obstructed = pointObstructions.length == 1 && pointObstructions[0] != undefined;
+    if (!obstructed) {
+      trianglesAsArraysOfPoints.push([p1, p2, p3]);
+    }
+  }
+  window.trianglesAsArraysOfPoints = trianglesAsArraysOfPoints;
+  return new NavMesh(trianglesAsArraysOfPoints);
 }
 
 // export interface INavMesh {
@@ -155,84 +182,84 @@ export function triangulate(worldSize: number, obstructions: Obstruction[]): ITr
 
 // }
 
-export function findPathWithAStar(unit: { position: Vector, collisionRadius: number }, destination: Vector, triangulatedMap: ITriangulatedMap): Vector[] | undefined {
-  if (unit.position.x < 0 || unit.position.y < 0 || unit.position.x >= triangulatedMap.worldSize || unit.position.y >= triangulatedMap.worldSize) {
-    return undefined;
-  }
+// export function findPathWithAStar(unit: { position: Vector, collisionRadius: number }, destination: Vector, triangulatedMap: ITriangulatedMap): Vector[] | undefined {
+//   if (unit.position.x < 0 || unit.position.y < 0 || unit.position.x >= triangulatedMap.worldSize || unit.position.y >= triangulatedMap.worldSize) {
+//     return undefined;
+//   }
 
-  let unitCell: [number, number] = vec2cell(unit.position);
-  unitCell[0] = Math.round(unitCell[0]);
-  unitCell[1] = Math.round(unitCell[1]);
+//   let unitCell: [number, number] = vec2cell(unit.position);
+//   unitCell[0] = Math.round(unitCell[0]);
+//   unitCell[1] = Math.round(unitCell[1]);
 
-  triangulatedMap.points.push(unitCell);
-  triangulatedMap.points.push(vec2cell(destination));
+//   triangulatedMap.points.push(unitCell);
+//   triangulatedMap.points.push(vec2cell(destination));
 
-  const pointsByCloseness = _.sortBy(triangulatedMap.points, (p) => Math.hypot(unitCell[0] - p[0], unitCell[1] - p[1]));
-  const nearestPoints_.take(nearestPoints, 3)
-  const nearestPointN = triangulatedMap.points.indexOf(nearestPoint!);
+//   const pointsByCloseness = _.sortBy(triangulatedMap.points, (p) => Math.hypot(unitCell[0] - p[0], unitCell[1] - p[1]));
+//   const nearestPoints_.take(nearestPoints, 3)
+//   const nearestPointN = triangulatedMap.points.indexOf(nearestPoint!);
 
-  const nearestPointToDestination = _.sortBy(triangulatedMap.points, (p) => Math.hypot(destination.x - p[0], destination.y - p[1]));
-  const nearestPointNToDestination = triangulatedMap.points.indexOf(nearestPointToDestination!);
+//   const nearestPointToDestination = _.sortBy(triangulatedMap.points, (p) => Math.hypot(destination.x - p[0], destination.y - p[1]));
+//   const nearestPointNToDestination = triangulatedMap.points.indexOf(nearestPointToDestination!);
 
-  let openSet: TinyQueue<[number, number]> = new TinyQueue([[nearestPointN, 0]], (a, b) => a[1] - b[1]);
-  let cameFrom = new Map<number, number>();
-  let gScore = new Map<number, number>();
-  gScore.set(nearestPointN, 0);
-  let fScore = new Map<number, number>();
-  fScore.set(nearestPointN, heuristic(nearestPoint!, destination));
-  let closed = new Set<number>();
+//   let openSet: TinyQueue<[number, number]> = new TinyQueue([[nearestPointN, 0]], (a, b) => a[1] - b[1]);
+//   let cameFrom = new Map<number, number>();
+//   let gScore = new Map<number, number>();
+//   gScore.set(nearestPointN, 0);
+//   let fScore = new Map<number, number>();
+//   fScore.set(nearestPointN, heuristic(nearestPoint!, destination));
+//   let closed = new Set<number>();
 
-  while (true) {
-    // console.log("len " + openSet.length);
-    let currentItem = openSet.pop();
-    if (currentItem === undefined) {
-      break;
-    }
-    let currentN = currentItem[0];
-    if (closed.has(currentN)) {
-      continue;
-    }
-    let current = triangulatedMap.points[currentN];
-    if (currentN == nearestPointNToDestination) {
-      const path = reconstructPath(cameFrom, currentN, triangulatedMap);
-      if (path.length > 0) {
-        if (path[0] != unit.position) {
-          path.unshift(unit.position);
-        }
-        path.push(destination);
-      }
-      return path;
-    }
-    closed.add(currentN);
-    for (let neighbourNWithCost of triangulatedMap.neighboursWithCost[currentN]) {
-      const neighbourN = neighbourNWithCost[0];
-      const neighbourCost = neighbourNWithCost[1];
-      const neighbour: [number, number] = triangulatedMap.points[neighbourN];
-      if (neighbour[0] < 0
-        || neighbour[1] < 0
-        || neighbour[0] >= triangulatedMap.worldSize
-        || neighbour[1] >= triangulatedMap.worldSize
-        || closed.has(neighbourN)) {
-        continue;
-      }
-      // let neighbourClearance = triangulatedMap.cells[neighbour[1]][neighbour[0]];
-      // if (neighbourClearance < unit.collisionRadius) {
-      //   continue;
-      // }
-      let tentativeGScore = gScore.get(currentN)! + neighbourCost;
-      let knownGScore = gScore.get(neighbourN);
-      if (knownGScore == undefined || tentativeGScore < knownGScore) {
-        const virtualUnit = { position: neighbour, collisionRadius: unit.collisionRadius };
-        cameFrom.set(neighbourN, currentN);
-        gScore.set(neighbourN, tentativeGScore);
-        const neighbourFScore = tentativeGScore + heuristic(neighbour, destination);
-        fScore.set(neighbourN, neighbourFScore);
-        openSet.push([neighbourN, neighbourFScore]);
-      }
-    }
-  }
-  return undefined;
-}
+//   while (true) {
+//     // console.log("len " + openSet.length);
+//     let currentItem = openSet.pop();
+//     if (currentItem === undefined) {
+//       break;
+//     }
+//     let currentN = currentItem[0];
+//     if (closed.has(currentN)) {
+//       continue;
+//     }
+//     let current = triangulatedMap.points[currentN];
+//     if (currentN == nearestPointNToDestination) {
+//       const path = reconstructPath(cameFrom, currentN, triangulatedMap);
+//       if (path.length > 0) {
+//         if (path[0] != unit.position) {
+//           path.unshift(unit.position);
+//         }
+//         path.push(destination);
+//       }
+//       return path;
+//     }
+//     closed.add(currentN);
+//     for (let neighbourNWithCost of triangulatedMap.neighboursWithCost[currentN]) {
+//       const neighbourN = neighbourNWithCost[0];
+//       const neighbourCost = neighbourNWithCost[1];
+//       const neighbour: [number, number] = triangulatedMap.points[neighbourN];
+//       if (neighbour[0] < 0
+//         || neighbour[1] < 0
+//         || neighbour[0] >= triangulatedMap.worldSize
+//         || neighbour[1] >= triangulatedMap.worldSize
+//         || closed.has(neighbourN)) {
+//         continue;
+//       }
+//       // let neighbourClearance = triangulatedMap.cells[neighbour[1]][neighbour[0]];
+//       // if (neighbourClearance < unit.collisionRadius) {
+//       //   continue;
+//       // }
+//       let tentativeGScore = gScore.get(currentN)! + neighbourCost;
+//       let knownGScore = gScore.get(neighbourN);
+//       if (knownGScore == undefined || tentativeGScore < knownGScore) {
+//         const virtualUnit = { position: neighbour, collisionRadius: unit.collisionRadius };
+//         cameFrom.set(neighbourN, currentN);
+//         gScore.set(neighbourN, tentativeGScore);
+//         const neighbourFScore = tentativeGScore + heuristic(neighbour, destination);
+//         fScore.set(neighbourN, neighbourFScore);
+//         openSet.push([neighbourN, neighbourFScore]);
+//       }
+//     }
+//   }
+//   return undefined;
+// }
 
 function reconstructPath(cameFrom: Map<number, number>, currentN: number | undefined, triangulatedMap: ITriangulatedMap): Vector[] {
   let path = [];

--- a/src/rtt_engine/pathfinding.ts
+++ b/src/rtt_engine/pathfinding.ts
@@ -1,0 +1,186 @@
+import { Vector } from './vector';
+import { Obstruction } from './entities';
+import TinyQueue from 'tinyqueue';
+
+export interface IClearance {
+  worldSize: number;
+  cells: number[][];
+}
+
+export function clearance(worldSize: number, obstructions: Obstruction[]): IClearance {
+  let cells = [];
+  for (let i = 0; i < worldSize; i++) {
+    let row = [];
+    for (let j = 0; j < worldSize; j++) {
+      row.push(Infinity);
+    }
+    cells.push(row);
+  }
+  let cameFrom: Map<string, number> = new Map();
+  for (let obstruction of obstructions) {
+    let open: Set<string> = new Set();
+    open.add(cell2str([Math.floor(obstruction.left), Math.floor(obstruction.top)]));
+    let closed: Set<string> = new Set();
+    while (open.size > 0) {
+      let current: [number, number] = str2cell(open.values().next().value);
+      open.delete(cell2str(current));
+      closed.add(cell2str(current));
+      let clearance;
+      if (obstruction.left <= current[0]
+        && obstruction.top <= current[1]
+        && obstruction.right >= current[0]
+        && obstruction.bottom >= current[1]) {
+        clearance = 0;
+      } else {
+        clearance = cameFrom.get(cell2str(current))!;
+      }
+      cells[current[1]][current[0]] = clearance;
+      for (let cellNeighboursAndCost of cellNeighboursAndCosts(current[0], current[1])) {
+        let cellNeighbour: [number, number] = [cellNeighboursAndCost[0], cellNeighboursAndCost[1]];
+        if (closed.has(cell2str(cellNeighbour)) || cellNeighbour[0] < 0 || cellNeighbour[1] < 0 || cellNeighbour[0] >= worldSize || cellNeighbour[1] >= worldSize) {
+          continue;
+        }
+        let totalCost = clearance + cellNeighboursAndCost[2];
+        open.add(cell2str(cellNeighbour));
+        if (!cameFrom.has(cell2str(cellNeighbour)) || totalCost < cameFrom.get(cell2str(cellNeighbour))!) {
+          cameFrom.set(cell2str(cellNeighbour), totalCost);
+        }
+      }
+    }
+  }
+  return { worldSize, cells };
+}
+
+// var c = document.getElementsByTagName("canvas")[0];
+// var ctx = c.getContext("2d");
+// var imgData = ctx.createImageData(temp1.width, temp1.height);
+// var max = Math.max(...temp1.cells.map((c) => Math.max(...c)));
+// for (var y = 0; y < temp1.height; y++) {
+//   for (var x = 0; x < temp1.width; x++) {
+//     var i = y * temp1.height + x;
+//     imgData.data[i * 4] = temp1.cells[y][x] / max * 255;
+//     imgData.data[i * 4 + 1] = 0;
+//     imgData.data[i * 4 + 2] = 0;
+//     imgData.data[i * 4 + 3] = 255;
+//   }
+// }
+// ctx.putImageData(imgData, 0, 0);
+
+function cellNeighboursAndCosts(x: number, y: number): [number, number, number][] {
+  let s = Math.sqrt(2);
+  return [
+    [x - 1, y, 1],
+    [x, y - 1, 1],
+    [x + 1, y, 1],
+    [x, y + 1, 1],
+    [x - 1, y - 1, s],
+    [x - 1, y + 1, s],
+    [x + 1, y - 1, s],
+    [x + 1, y + 1, s],
+  ];
+}
+
+function cell2str(cell: [number, number]): string {
+  return `${cell[0]}x${cell[1]}`;
+}
+
+function str2cell(s: string): [number, number] {
+  let segments = s.split("x");
+  return [parseInt(segments[0]), parseInt(segments[1])];
+}
+
+function vec2cell(v: Vector): [number, number] {
+  return [v.x, v.y];
+}
+
+export function findPathWithAStar(unit: { position: Vector, collisionRadius: number }, destination: Vector, clearance: IClearance): Vector[] | undefined {
+  if (unit.position.x < 0 || unit.position.y < 0 || unit.position.x >= clearance.worldSize || unit.position.y >= clearance.worldSize) {
+    return undefined;
+  }
+
+  let unitCell: [number, number] = vec2cell(unit.position);
+  unitCell[0] = Math.round(unitCell[0]);
+  unitCell[1] = Math.round(unitCell[1]);
+  let unitCellN = unitCell[0] + unitCell[1] * clearance.worldSize;
+
+  let openSet: TinyQueue<[[number, number], number]> = new TinyQueue([[unitCell, 0]], (a, b) => a[1] - b[1]);
+  let cameFrom = new Map<number, [number, number]>();
+  let gScore = new Map<number, number>();
+  gScore.set(unitCellN, 0);
+  let fScore = new Map<number, number>();
+  fScore.set(unitCellN, heuristic(unitCell, destination));
+  let closed = new Set<number>();
+
+  while (true) {
+    // console.log("len " + openSet.length);
+    let currentItem = openSet.pop();
+    if (currentItem === undefined) {
+      break;
+    }
+    let current = currentItem[0];
+    let currentN = current[0] + current[1] * clearance.worldSize;
+    if (closed.has(currentN)) {
+      continue;
+    }
+    if (current[0] == destination.x && current[1] == destination.y) {
+      return reconstructPath(cameFrom, current, clearance.worldSize);
+    }
+    //openSet = openSet.filter((v) => !v.equals(current!));
+    closed.add(currentN);
+    for (let neighbourWithCost of cellNeighboursAndCosts(...current)) {
+      let neighbour: [number, number] = [neighbourWithCost[0], neighbourWithCost[1]];
+      let cost = neighbourWithCost[2];
+      if (neighbour[0] < 0 || neighbour[1] < 0 || neighbour[0] >= clearance.worldSize || neighbour[1] >= clearance.worldSize || closed.has(cell2str(neighbour))) {
+        continue;
+      }
+      let neighbourClearance = clearance.cells[neighbour[1]][neighbour[0]];
+      if (neighbourClearance < unit.collisionRadius) {
+        continue;
+      }
+      let neighbourN = neighbour[0] + neighbour[1] * clearance.worldSize;
+      let tentativeGScore = gScore.get(currentN)! + cost;
+      let knownGScore = gScore.get(neighbourN);
+      if (knownGScore == undefined || tentativeGScore < knownGScore) {
+        const virtualUnit = { position: neighbour, collisionRadius: unit.collisionRadius };
+        cameFrom.set(neighbourN, current);
+        gScore.set(neighbourN, tentativeGScore);
+        const neighbourFScore = tentativeGScore + heuristic(neighbour, destination);
+        fScore.set(neighbourN, neighbourFScore);
+        openSet.push([neighbour, neighbourFScore]);
+      }
+    }
+    //openSet = _.sortBy(openSet, (v) => fScore.get(vec2str(v)));
+  }
+  return undefined;
+}
+
+function reconstructPath(cameFrom: Map<number, [number, number]>, current: [number, number], worldSize: number): Vector[] {
+  let path = [];
+  while (current != undefined) {
+    path.unshift(new Vector(current[0], current[1]));
+    let currentN = current[0] + current[1] * worldSize;
+    current = cameFrom.get(currentN);
+  }
+  return path;
+}
+
+function heuristic(from: [number, number], destination: Vector): number {
+  return Math.hypot(destination.x - from[0], destination.y - from[1]);
+}
+
+function neighbours(of: Vector): Vector[] {
+  return [
+    new Vector(of.x - 1, of.y),
+    new Vector(of.x, of.y - 1),
+    new Vector(of.x + 1, of.y),
+    new Vector(of.x, of.y + 1),
+    new Vector(of.x - 1, of.y - 1),
+    new Vector(of.x - 1, of.y + 1),
+    new Vector(of.x + 1, of.y + 1),
+    new Vector(of.x + 1, of.y - 1),
+  ];
+}
+
+function vec2str(v: Vector): string {
+  return `Vector[${v.x}, ${v.y}]`;
+}

--- a/src/rtt_engine/pathfinding.ts
+++ b/src/rtt_engine/pathfinding.ts
@@ -1,293 +1,83 @@
 import { Vector } from './vector';
 import { Obstruction } from './entities';
 import TinyQueue from 'tinyqueue';
-import Delaunator from 'delaunator';
 import { NavMesh } from "nav2d";
-
-export interface IClearance {
-  worldSize: number;
-  cells: number[][];
-}
-
-export function clearance(worldSize: number, obstructions: Obstruction[]): IClearance {
-  let cells = [];
-  for (let i = 0; i < worldSize; i++) {
-    let row = [];
-    for (let j = 0; j < worldSize; j++) {
-      row.push(Infinity);
-    }
-    cells.push(row);
-  }
-  let cameFrom: Map<string, number> = new Map();
-  for (let obstruction of obstructions) {
-    let open: Set<string> = new Set();
-    open.add(cell2str([Math.floor(obstruction.left), Math.floor(obstruction.top)]));
-    let closed: Set<string> = new Set();
-    while (open.size > 0) {
-      let current: [number, number] = str2cell(open.values().next().value);
-      open.delete(cell2str(current));
-      closed.add(cell2str(current));
-      let clearance;
-      if (obstruction.left <= current[0]
-        && obstruction.top <= current[1]
-        && obstruction.right >= current[0]
-        && obstruction.bottom >= current[1]) {
-        clearance = 0;
-      } else {
-        clearance = cameFrom.get(cell2str(current))!;
-      }
-      cells[current[1]][current[0]] = clearance;
-      for (let cellNeighboursAndCost of cellNeighboursAndCosts(current[0], current[1])) {
-        let cellNeighbour: [number, number] = [cellNeighboursAndCost[0], cellNeighboursAndCost[1]];
-        if (closed.has(cell2str(cellNeighbour)) || cellNeighbour[0] < 0 || cellNeighbour[1] < 0 || cellNeighbour[0] >= worldSize || cellNeighbour[1] >= worldSize) {
-          continue;
-        }
-        let totalCost = clearance + cellNeighboursAndCost[2];
-        open.add(cell2str(cellNeighbour));
-        if (!cameFrom.has(cell2str(cellNeighbour)) || totalCost < cameFrom.get(cell2str(cellNeighbour))!) {
-          cameFrom.set(cell2str(cellNeighbour), totalCost);
-        }
-      }
-    }
-  }
-  return { worldSize, cells };
-}
-
-// var c = document.getElementsByTagName("canvas")[0];
-// var ctx = c.getContext("2d");
-// var imgData = ctx.createImageData(temp1.width, temp1.height);
-// var max = Math.max(...temp1.cells.map((c) => Math.max(...c)));
-// for (var y = 0; y < temp1.height; y++) {
-//   for (var x = 0; x < temp1.width; x++) {
-//     var i = y * temp1.height + x;
-//     imgData.data[i * 4] = temp1.cells[y][x] / max * 255;
-//     imgData.data[i * 4 + 1] = 0;
-//     imgData.data[i * 4 + 2] = 0;
-//     imgData.data[i * 4 + 3] = 255;
-//   }
-// }
-// ctx.putImageData(imgData, 0, 0);
-
-function cellNeighboursAndCosts(x: number, y: number): [number, number, number][] {
-  let s = Math.sqrt(2);
-  return [
-    [x - 1, y, 1],
-    [x, y - 1, 1],
-    [x + 1, y, 1],
-    [x, y + 1, 1],
-    [x - 1, y - 1, s],
-    [x - 1, y + 1, s],
-    [x + 1, y - 1, s],
-    [x + 1, y + 1, s],
-  ];
-}
-
-function cell2str(cell: [number, number]): string {
-  return `${cell[0]}x${cell[1]}`;
-}
-
-function str2cell(s: string): [number, number] {
-  let segments = s.split("x");
-  return [parseInt(segments[0]), parseInt(segments[1])];
-}
-
-function vec2cell(v: Vector): [number, number] {
-  return [v.x, v.y];
-}
+import cleanPSLG from "clean-pslg";
+import cdt2d from "cdt2d";
 
 export interface ITriangulatedMap {
   worldSize: number;
   points: [number, number][];
-  pointObstruction: (number | undefined)[];
-  triangles: Uint32Array;
-  neighboursWithCost: [number, number][][];
-  badPoints: [number, number][];
+  triangles: [number, number, number][];
+  passableTriangles: [number, number, number][];
 }
 
 export function triangulate(worldSize: number, obstructions: Obstruction[]): ITriangulatedMap {
   const points: [number, number][] = [];
+  const boundaryEdges: [number, number][] = [];
+
+  // Add the world boundaries
   points.push([0, 0]);
   points.push([0, worldSize]);
   points.push([worldSize, worldSize]);
   points.push([worldSize, 0]);
-  const pointObstruction = [undefined, undefined, undefined, undefined];
-  let i = 0;
-  let badPoints: [number, number][] = [];
+  boundaryEdges.push([0, 1]);
+  boundaryEdges.push([1, 2]);
+  boundaryEdges.push([2, 3]);
+  boundaryEdges.push([3, 0]);
+
+  // Add the obstructions
   for (let obstruction of obstructions) {
+    const startIndex = points.length;
     points.push([obstruction.left, obstruction.top]);
     points.push([obstruction.right, obstruction.top]);
     points.push([obstruction.right, obstruction.bottom]);
     points.push([obstruction.left, obstruction.bottom]);
-    badPoints.push([obstruction.left, obstruction.top]);
-    badPoints.push([obstruction.right, obstruction.top]);
-    badPoints.push([obstruction.right, obstruction.bottom]);
-    badPoints.push([obstruction.left, obstruction.bottom]);
-    pointObstruction.push(i, i, i, i);
-    i++;
+    boundaryEdges.push([startIndex, startIndex+1]);
+    boundaryEdges.push([startIndex+1, startIndex+2]);
+    boundaryEdges.push([startIndex+2, startIndex+3]);
+    boundaryEdges.push([startIndex+3, startIndex]);
   }
-  const delauneyed = Delaunator.from(points);
-  const neighboursWithCost: [number, number][][] = points.map((p) => []);
-  for (let i = 0; i < delauneyed.triangles.length; i += 3) {
-    const p1N = delauneyed.triangles[i];
-    const p2N = delauneyed.triangles[i + 1];
-    const p3N = delauneyed.triangles[i + 2];
-    const p1 = points[p1N];
-    const p2 = points[p2N];
-    const p3 = points[p3N];
-    const p1ToP2 = Math.hypot(p2[0] - p1[0], p2[1] - p1[1]);
-    neighboursWithCost[p1N].push([p2N, p1ToP2]);
-    neighboursWithCost[p2N].push([p1N, p1ToP2]);
-    const p1ToP3 = Math.hypot(p3[0] - p1[0], p3[1] - p1[1]);
-    neighboursWithCost[p1N].push([p3N, p1ToP3]);
-    neighboursWithCost[p3N].push([p1N, p1ToP3]);
-    const p2ToP3 = Math.hypot(p3[0] - p2[0], p3[1] - p2[1]);
-    neighboursWithCost[p2N].push([p3N, p2ToP3]);
-    neighboursWithCost[p3N].push([p2N, p2ToP3]);
+
+  if (!cleanPSLG(points, boundaryEdges)) {
+    alert("cleaning the map before triangulation failed. sorry. contact the author :(");
   }
+
+  const triangles = cdt2d(points, boundaryEdges);
+
+  const passableTriangles: [number, number, number][] = [];
+  for (let triangle of triangles) {
+    let trianglePoints = triangle.map((i) => points[i]);
+    let centreOfTriangle = [
+      _.sum(trianglePoints.map((p) => p[0])) / 3,
+      _.sum(trianglePoints.map((p) => p[1])) / 3,
+    ];
+    let obstructed = false;
+    for (let obstruction of obstructions) {
+      if (obstruction.left < centreOfTriangle[0]
+        && obstruction.right > centreOfTriangle[0]
+        && obstruction.top < centreOfTriangle[1]
+        && obstruction.bottom > centreOfTriangle[1]) {
+        obstructed = true;
+        break;
+      }
+    }
+    if (!obstructed) {
+      passableTriangles.push(triangle);
+    }
+  }
+
   return {
-    worldSize: worldSize,
+    worldSize,
     points,
-    pointObstruction,
-    triangles: delauneyed.triangles,
-    neighboursWithCost,
-    badPoints,
+    triangles,
+    passableTriangles,
   };
 }
 
 export function triangulatedMapToNavMesh(triangulatedMap: ITriangulatedMap): NavMesh {
-  const trianglesAsArraysOfPoints: [number, number][][] = [];
-  for (let i = 0; i < triangulatedMap.triangles.length; i += 3) {
-    const p1N = triangulatedMap.triangles[i];
-    const p2N = triangulatedMap.triangles[i + 1];
-    const p3N = triangulatedMap.triangles[i + 2];
-    const p1 = triangulatedMap.points[p1N];
-    const p2 = triangulatedMap.points[p2N];
-    const p3 = triangulatedMap.points[p3N];
-    let pointObstructions = _.uniq([p1N, p2N, p3N].map((n) => triangulatedMap.pointObstruction[n]));
-    let obstructed = pointObstructions.length == 1 && pointObstructions[0] != undefined;
-    if (!obstructed) {
-      trianglesAsArraysOfPoints.push([p1, p2, p3]);
-    }
-  }
-  window.trianglesAsArraysOfPoints = trianglesAsArraysOfPoints;
+  const trianglesAsArraysOfPoints = triangulatedMap.passableTriangles.map((triangle) => {
+    return triangle.map((i) => triangulatedMap.points[i]);
+  });
   return new NavMesh(trianglesAsArraysOfPoints);
-}
-
-// export interface INavMesh {
-//   worldSize: number;
-//   navMesh: number[][];
-// }
-
-// export function navmesh(clearance: IClearance): INavMesh {
-
-// }
-
-// export function findPathWithAStar(unit: { position: Vector, collisionRadius: number }, destination: Vector, triangulatedMap: ITriangulatedMap): Vector[] | undefined {
-//   if (unit.position.x < 0 || unit.position.y < 0 || unit.position.x >= triangulatedMap.worldSize || unit.position.y >= triangulatedMap.worldSize) {
-//     return undefined;
-//   }
-
-//   let unitCell: [number, number] = vec2cell(unit.position);
-//   unitCell[0] = Math.round(unitCell[0]);
-//   unitCell[1] = Math.round(unitCell[1]);
-
-//   triangulatedMap.points.push(unitCell);
-//   triangulatedMap.points.push(vec2cell(destination));
-
-//   const pointsByCloseness = _.sortBy(triangulatedMap.points, (p) => Math.hypot(unitCell[0] - p[0], unitCell[1] - p[1]));
-//   const nearestPoints_.take(nearestPoints, 3)
-//   const nearestPointN = triangulatedMap.points.indexOf(nearestPoint!);
-
-//   const nearestPointToDestination = _.sortBy(triangulatedMap.points, (p) => Math.hypot(destination.x - p[0], destination.y - p[1]));
-//   const nearestPointNToDestination = triangulatedMap.points.indexOf(nearestPointToDestination!);
-
-//   let openSet: TinyQueue<[number, number]> = new TinyQueue([[nearestPointN, 0]], (a, b) => a[1] - b[1]);
-//   let cameFrom = new Map<number, number>();
-//   let gScore = new Map<number, number>();
-//   gScore.set(nearestPointN, 0);
-//   let fScore = new Map<number, number>();
-//   fScore.set(nearestPointN, heuristic(nearestPoint!, destination));
-//   let closed = new Set<number>();
-
-//   while (true) {
-//     // console.log("len " + openSet.length);
-//     let currentItem = openSet.pop();
-//     if (currentItem === undefined) {
-//       break;
-//     }
-//     let currentN = currentItem[0];
-//     if (closed.has(currentN)) {
-//       continue;
-//     }
-//     let current = triangulatedMap.points[currentN];
-//     if (currentN == nearestPointNToDestination) {
-//       const path = reconstructPath(cameFrom, currentN, triangulatedMap);
-//       if (path.length > 0) {
-//         if (path[0] != unit.position) {
-//           path.unshift(unit.position);
-//         }
-//         path.push(destination);
-//       }
-//       return path;
-//     }
-//     closed.add(currentN);
-//     for (let neighbourNWithCost of triangulatedMap.neighboursWithCost[currentN]) {
-//       const neighbourN = neighbourNWithCost[0];
-//       const neighbourCost = neighbourNWithCost[1];
-//       const neighbour: [number, number] = triangulatedMap.points[neighbourN];
-//       if (neighbour[0] < 0
-//         || neighbour[1] < 0
-//         || neighbour[0] >= triangulatedMap.worldSize
-//         || neighbour[1] >= triangulatedMap.worldSize
-//         || closed.has(neighbourN)) {
-//         continue;
-//       }
-//       // let neighbourClearance = triangulatedMap.cells[neighbour[1]][neighbour[0]];
-//       // if (neighbourClearance < unit.collisionRadius) {
-//       //   continue;
-//       // }
-//       let tentativeGScore = gScore.get(currentN)! + neighbourCost;
-//       let knownGScore = gScore.get(neighbourN);
-//       if (knownGScore == undefined || tentativeGScore < knownGScore) {
-//         const virtualUnit = { position: neighbour, collisionRadius: unit.collisionRadius };
-//         cameFrom.set(neighbourN, currentN);
-//         gScore.set(neighbourN, tentativeGScore);
-//         const neighbourFScore = tentativeGScore + heuristic(neighbour, destination);
-//         fScore.set(neighbourN, neighbourFScore);
-//         openSet.push([neighbourN, neighbourFScore]);
-//       }
-//     }
-//   }
-//   return undefined;
-// }
-
-function reconstructPath(cameFrom: Map<number, number>, currentN: number | undefined, triangulatedMap: ITriangulatedMap): Vector[] {
-  let path = [];
-  while (currentN != undefined) {
-    const current = triangulatedMap.points[currentN];
-    path.unshift(new Vector(current[0], current[1]));
-    currentN = cameFrom.get(currentN);
-  }
-  return path;
-}
-
-function heuristic(from: [number, number], destination: Vector): number {
-  return Math.hypot(destination.x - from[0], destination.y - from[1]);
-}
-
-function neighbours(of: Vector): Vector[] {
-  return [
-    new Vector(of.x - 1, of.y),
-    new Vector(of.x, of.y - 1),
-    new Vector(of.x + 1, of.y),
-    new Vector(of.x, of.y + 1),
-    new Vector(of.x - 1, of.y - 1),
-    new Vector(of.x - 1, of.y + 1),
-    new Vector(of.x + 1, of.y + 1),
-    new Vector(of.x + 1, of.y - 1),
-  ];
-}
-
-function vec2str(v: Vector): string {
-  return `Vector[${v.x}, ${v.y}]`;
 }

--- a/src/rtt_engine/vector.ts
+++ b/src/rtt_engine/vector.ts
@@ -74,4 +74,8 @@ export class Vector {
       this.y /= magnitude;
     }
   }
+
+  public equals(v2: Vector): boolean {
+    return this.x == v2.x && this.y == v2.y;
+  }
 }

--- a/src/rtt_engine/vector.ts
+++ b/src/rtt_engine/vector.ts
@@ -78,4 +78,8 @@ export class Vector {
   public equals(v2: Vector): boolean {
     return this.x == v2.x && this.y == v2.y;
   }
+
+  public stringify(): string {
+    return `Vector[${this.x}, ${this.y}]`;
+  }
 }

--- a/src/rtt_threejs_renderer/index.ts
+++ b/src/rtt_threejs_renderer/index.ts
@@ -13,3 +13,4 @@ export * from './presenters/turret_presenter';
 export * from './presenters/turret_projectile_presenter';
 export * from './presenters/map_presenter';
 export * from './presenters/obstruction_presenter';
+export * from './presenters/triangulated_map_presenter';

--- a/src/rtt_threejs_renderer/index.ts
+++ b/src/rtt_threejs_renderer/index.ts
@@ -12,3 +12,4 @@ export * from './presenters/power_generator_presenter';
 export * from './presenters/turret_presenter';
 export * from './presenters/turret_projectile_presenter';
 export * from './presenters/map_presenter';
+export * from './presenters/obstruction_presenter';

--- a/src/rtt_threejs_renderer/presenters/bot_presenter.ts
+++ b/src/rtt_threejs_renderer/presenters/bot_presenter.ts
@@ -17,7 +17,7 @@ export class BotPresenter extends InstancedRotateablePresenter {
     super(
       player,
       (p) => p.units.vehicles.filter(v => v instanceof Bot),
-      new THREE.ShapeBufferGeometry(botShape())
+      new THREE.ShapeBufferGeometry(botShape()),
       scene,
     );
   }

--- a/src/rtt_threejs_renderer/presenters/obstruction_presenter.ts
+++ b/src/rtt_threejs_renderer/presenters/obstruction_presenter.ts
@@ -1,0 +1,60 @@
+import * as THREE from 'three';
+import { Obstruction } from '../../rtt_engine/entities';
+import { Vector } from '../../rtt_engine/vector';
+import { Game } from '../../rtt_engine';
+
+export function obstructionShape(): THREE.Shape {
+  var shape = new THREE.Shape();
+  shape.moveTo(-0.5, -0.5);
+  shape.lineTo(0.5, -0.5);
+  shape.lineTo(0.5, 0.5);
+  shape.lineTo(-0.5, 0.5);
+  return shape;
+}
+
+export class ObstructionPresenter {
+  game: Game;
+  scene: THREE.Group;
+  material?: THREE.Material;
+  geometry?: THREE.BufferGeometry;
+  instancedMesh?: THREE.InstancedMesh;
+
+  constructor(game: Game, scene: THREE.Group) {
+    this.game = game;
+    this.scene = scene;
+    this.material = new THREE.MeshBasicMaterial({ color: new THREE.Color(0x202020) });
+    this.geometry = new THREE.ShapeBufferGeometry(obstructionShape());
+  }
+
+  predraw() { }
+
+  draw() {
+    const instances = this.game.obstructions;
+    const instanceCount = instances.length;
+    if (this.instancedMesh != undefined && this.instancedMesh.count != instanceCount) {
+      this.scene.remove(this.instancedMesh);
+      this.instancedMesh = undefined;
+    }
+    if (this.instancedMesh == undefined) {
+      this.instancedMesh = new THREE.InstancedMesh(this.geometry!, this.material!, instanceCount);
+      this.instancedMesh.count = instanceCount;
+      this.instancedMesh.frustumCulled = false;
+      this.scene.add(this.instancedMesh);
+    }
+    let m = new THREE.Matrix4();
+    for (let i = 0; i < instanceCount; i++) {
+      const instance = instances[i];
+      m.makeScale(instance.right - instance.left, instance.bottom - instance.top, 1);
+      m.setPosition(instance.position.x, instance.position.y, 0);
+      this.instancedMesh.setMatrixAt(i, m);
+    }
+    this.instancedMesh.instanceMatrix.needsUpdate = true;
+  }
+
+  dedraw() {
+    if (this.instancedMesh) {
+      this.scene.remove(this.instancedMesh);
+      this.instancedMesh = undefined;
+    }
+  }
+}

--- a/src/rtt_threejs_renderer/presenters/triangulated_map_presenter.ts
+++ b/src/rtt_threejs_renderer/presenters/triangulated_map_presenter.ts
@@ -1,0 +1,56 @@
+import * as THREE from 'three';
+import { Vector } from '../../rtt_engine/vector';
+import { ITriangulatedMap } from '../../rtt_engine';
+
+export class TriangulatedMapPresenter {
+  triangulatedMap: ITriangulatedMap;
+  scene: THREE.Group;
+  childScene?: THREE.Group;
+
+  constructor(triangulatedMap: ITriangulatedMap, scene: THREE.Group) {
+    this.triangulatedMap = triangulatedMap;
+    this.scene = scene;
+  }
+
+  predraw() {
+    this.childScene = new THREE.Group();
+    for (let i = 0; i < this.triangulatedMap.triangles.length; i += 3) {
+      let pointNumbers = [
+        this.triangulatedMap.triangles[i],
+        this.triangulatedMap.triangles[i + 1],
+        this.triangulatedMap.triangles[i + 2],
+      ];
+      let pointObstructions = _.uniq(pointNumbers.map((n) => this.triangulatedMap.pointObstruction[n]));
+      let obstructed = pointObstructions.length == 1 && pointObstructions[0] != undefined;
+      let coords = pointNumbers.map((n) => this.triangulatedMap.points[n]);
+      this.drawTriangle(coords, obstructed);
+    }
+    this.scene.add(this.childScene);
+  }
+
+  draw() { }
+
+  protected drawTriangle(points: [number, number][], obstructed: boolean) {
+    let geometry = new THREE.Geometry();
+    let vertices = points.map((p) => new THREE.Vector3(p[0], p[1], 2));
+    console.log(vertices);
+    geometry.vertices.push(...vertices);
+    geometry.faces.push(new THREE.Face3(0, 1, 2));
+    geometry.faces.push(new THREE.Face3(2, 1, 0));
+    geometry.faces.push(new THREE.Face3(2, 0, 1));
+    geometry.computeFaceNormals();
+    let material = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(obstructed ? 0xff0000 : Math.random() * 0x00ffff),
+    });
+    let mesh = new THREE.Mesh(geometry, material);
+    this.childScene!.add(mesh);
+  }
+
+  dedraw() {
+    if (this.childScene != null) {
+      this.scene.remove(this.childScene);
+      // FIXME: stop leaking the geometry and mesh and scene
+      this.childScene = undefined;
+    }
+  }
+}

--- a/src/rtt_threejs_renderer/presenters/triangulated_map_presenter.ts
+++ b/src/rtt_threejs_renderer/presenters/triangulated_map_presenter.ts
@@ -31,8 +31,11 @@ export class TriangulatedMapPresenter {
   draw() { }
 
   protected drawTriangle(points: [number, number][], obstructed: boolean) {
+    if (obstructed) {
+      return;
+    }
     let geometry = new THREE.Geometry();
-    let vertices = points.map((p) => new THREE.Vector3(p[0], p[1], 2));
+    let vertices = points.map((p) => new THREE.Vector3(p[0], p[1], -2));
     console.log(vertices);
     geometry.vertices.push(...vertices);
     geometry.faces.push(new THREE.Face3(0, 1, 2));
@@ -40,8 +43,10 @@ export class TriangulatedMapPresenter {
     geometry.faces.push(new THREE.Face3(2, 0, 1));
     geometry.computeFaceNormals();
     let material = new THREE.MeshBasicMaterial({
-      color: new THREE.Color(obstructed ? 0xff0000 : Math.random() * 0x00ffff),
+      color: new THREE.Color(obstructed ? 0xff0000 : Math.random() * 0xffffff),
+      opacity: 0.5,
     });
+    material.transparent = true;
     let mesh = new THREE.Mesh(geometry, material);
     this.childScene!.add(mesh);
   }

--- a/src/rtt_threejs_renderer/presenters/triangulated_map_presenter.ts
+++ b/src/rtt_threejs_renderer/presenters/triangulated_map_presenter.ts
@@ -14,26 +14,16 @@ export class TriangulatedMapPresenter {
 
   predraw() {
     this.childScene = new THREE.Group();
-    for (let i = 0; i < this.triangulatedMap.triangles.length; i += 3) {
-      let pointNumbers = [
-        this.triangulatedMap.triangles[i],
-        this.triangulatedMap.triangles[i + 1],
-        this.triangulatedMap.triangles[i + 2],
-      ];
-      let pointObstructions = _.uniq(pointNumbers.map((n) => this.triangulatedMap.pointObstruction[n]));
-      let obstructed = pointObstructions.length == 1 && pointObstructions[0] != undefined;
-      let coords = pointNumbers.map((n) => this.triangulatedMap.points[n]);
-      this.drawTriangle(coords, obstructed);
+    for (let passableTriangle of this.triangulatedMap.passableTriangles) {
+      let coords = passableTriangle.map((i) => this.triangulatedMap.points[i]);
+      this.drawTriangle(coords);
     }
     this.scene.add(this.childScene);
   }
 
   draw() { }
 
-  protected drawTriangle(points: [number, number][], obstructed: boolean) {
-    if (obstructed) {
-      return;
-    }
+  protected drawTriangle(points: [number, number][]) {
     let geometry = new THREE.Geometry();
     let vertices = points.map((p) => new THREE.Vector3(p[0], p[1], -2));
     console.log(vertices);
@@ -43,7 +33,7 @@ export class TriangulatedMapPresenter {
     geometry.faces.push(new THREE.Face3(2, 0, 1));
     geometry.computeFaceNormals();
     let material = new THREE.MeshBasicMaterial({
-      color: new THREE.Color(obstructed ? 0xff0000 : Math.random() * 0xffffff),
+      color: new THREE.Color(Math.random() * 0xffffff),
       opacity: 0.5,
     });
     material.transparent = true;


### PR DESCRIPTION
`rtt` is an experiment, so the code is not even meant to be tidy. (Although there are some nice mixin patterns.)

Until now RTT has had completely open maps. The world had a boundary that units can't cross, but they could move anywhere on the map. This meant that pathfinding was trivial: steer towards your destination and move forward. But open maps don't offer any depth of strategy: you can't take advantage of terrain or find a better position. Generally it wasn't very compelling.

This PR adds support for obstacles and adds a ➕-shaped obstacle to the middle of the map. These obstacles (known as "obstructions" in the codebase) can't be crossed by units. Any unit that collides with them can't go inside. Units now pathfind to their destination, using a navmesh.

Since this PR is just for my own records I don't want to go into too much depth about the pipeline used to build/use the navmesh (see the commit messages.) Big thanks thought to @frapa, the author of https://github.com/frapa/nav2d which is used for pathfinding across the navmesh. During this project I found a few bugs which they fixed for me. The funnel algorithm hurts my head when I try to program it so I'm incredibly grateful for their library.